### PR TITLE
Change cassandra server port to 9042

### DIFF
--- a/deployment_scripts/puppet/modules/contrail/templates/config.global.js.erb
+++ b/deployment_scripts/puppet/modules/contrail/templates/config.global.js.erb
@@ -174,7 +174,7 @@ config.files.download_path = '/tmp';
 /* Cassandra Server */
 config.cassandra = {};
 config.cassandra.server_ips = [<%= scope.lookupvar('contrail::contrail_controller_ips').map{ |ip| "'#{ip}'" }.join(',') %>];
-config.cassandra.server_port = '9160';
+config.cassandra.server_port = '9042';
 config.cassandra.enable_edit = false;
 
 /* KUE Job Scheduler */


### PR DESCRIPTION
Up to contrail 3.2 version,contrail-webui was switched to other Cassandra driver for Node.js, which is not compatible with previous one. The plugin should change port from 9160 to 9042.